### PR TITLE
Old job handling improvements

### DIFF
--- a/server-node/commitutil.js
+++ b/server-node/commitutil.js
@@ -35,7 +35,7 @@ function handleGetCommitRequests(state) {
 
         // Remove old webhooks that we don't want to reprocess.
         docs = docs.filter(function (doc) {
-            return (now - doc.time <= 7 * 24 * 3600e3);
+            return (now - doc.time <= state.oldCommitAgeDays * 24 * 3600e3);
         });
 
         // Sort docs: newest (largest) first, so we execute latest jobs and

--- a/server-node/config.yaml
+++ b/server-node/config.yaml
@@ -25,6 +25,13 @@ githubAuthUsername: 'foouser'
 githubAuthPassword: 'foopass'
 githubStatusUsername: 'foouser'
 
+# After this many days commits are considered too old and do not
+# trigger jobs.
+oldCommitAgeDays: 14
+
+# After this many days a pending run is considered failed and retried.
+pendingAutoFailDays: 2
+
 # Github rate limitation; ensures testrunner server doesn't hammer Github
 # in case a code or configuration bug causes repeated requests to be made.
 githubTokensPerHour: 120

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -101,13 +101,21 @@ function main() {
             console.log('Duktape testrunner server listening at https://%s:%s', host, port);
         });
 
-        // Background job for hanging request timeouts, persistent
+        // Short interval background job for hanging request timeouts, persistent
         // Github pushes, etc.
-        function periodicDatabaseScan() {
+        function shortPeriodicDatabaseScan() {
             githubutil.pushGithubStatuses(state);       // persistent github status pushing
             commitutil.handleGetCommitRequests(state);  // webhook client timeouts
         }
-        var dbScanTimer = setInterval(periodicDatabaseScan, 5000);
+        var shortDbScanTimer = setInterval(shortPeriodicDatabaseScan, 5 * 1000);
+
+        // Long interval background job for detecting timed out jobs, etc.
+        function longPeriodicDatabaseScan() {
+            console.log('long periodic database scan');
+            commitutil.handleAutoFailPending(state);    // autofail too old pending runs
+        }
+        var longDbScanTimer = setInterval(longPeriodicDatabaseScan, 3600 * 1000);
+        setTimeout(longPeriodicDatabaseScan, 1000);  // run once right away
     });
 }
 


### PR DESCRIPTION
- Make "old age" limit configurable.
- When a context is pending for too long (e.g. 2 days), automtically make it eligible for a rerun. This is a very bare bones mechanism for recovering from interrupted or fluke failed jobs.